### PR TITLE
fix: 非 0 code 作为异常响应处理

### DIFF
--- a/docs/zh/reference/plugin/plugins/request.md
+++ b/docs/zh/reference/plugin/plugins/request.md
@@ -59,11 +59,14 @@ export const request = {
     // 内部以 reponse.data.code === '0' 判断请求是否成功
     // 若使用其他字段判断，可以使用 responseDataAdaptor 对响应数据进行格式
     errorHandler: {
-        11199: (response) => {
+        11199(response) {
+            // 特殊 code 处理逻辑
+        },
+        404(error) {
 
         },
-        404: (error) => {
-
+        commonAbnormalCodeHandler(response) {
+            // 非 0，且非 11199(前面已经配置过 11199) code 其他异常code处理逻辑
         }
     },
     // 其他 axios 配置

--- a/docs/zh/reference/plugin/plugins/request.md
+++ b/docs/zh/reference/plugin/plugins/request.md
@@ -65,8 +65,8 @@ export const request = {
         404(error) {
 
         },
-        commonAbnormalCodeHandler(response) {
-            // 非 0，且非 11199(前面已经配置过 11199) code 其他异常code处理逻辑
+        default(error) {
+            // 异常统一处理
         }
     },
     // 其他 axios 配置

--- a/packages/create-fes-app/templates/app/h5/.fes.js
+++ b/packages/create-fes-app/templates/app/h5/.fes.js
@@ -31,6 +31,6 @@ export default {
         })
     ],
     devServer: {
-        port: 8080
+        port: 8000
     }
 };

--- a/packages/create-fes-app/templates/app/pc/.fes.js
+++ b/packages/create-fes-app/templates/app/pc/.fes.js
@@ -26,7 +26,7 @@ export default {
         legacy: true
     },
     devServer: {
-        port: 8080
+        port: 8000
     },
     enums: {
         status: [['0', '无效的'], ['1', '有效的']]

--- a/packages/fes-plugin-request/src/template/resErrorProcess.js
+++ b/packages/fes-plugin-request/src/template/resErrorProcess.js
@@ -1,12 +1,26 @@
 import { isObject } from './helpers';
 
-export default async ({
-    error,
-    errorHandler = {},
-    response
-}, next) => {
-    if (response && isObject(response.data) && response.data.code && response.data.code !== '0') {
-        errorHandler[response.data.code] && errorHandler[response.data.code](response);
+function handleAbnormalCode(errorHandler = {}, code, response) {
+    if (errorHandler[code]) {
+        errorHandler[code](response);
+    } else if (errorHandler.commonAbnormalCodeHandler) {
+        // 处理其他异常
+        errorHandler.commonAbnormalCodeHandler(response);
+    }
+}
+
+export default async (ctx, next) => {
+    const {
+        error,
+        errorHandler = {},
+        response
+    } = ctx;
+    if (response && isObject(response.data)) {
+        const code = response.data.code;
+        if (code !== '0') {
+            handleAbnormalCode(errorHandler, code, response);
+            ctx.error = response; // code 不为零进入 reject
+        }
     } else if (error) {
         if (error.type) {
             errorHandler[error.type] && errorHandler[error.type](error);

--- a/packages/fes-template-h5/.fes.js
+++ b/packages/fes-template-h5/.fes.js
@@ -33,6 +33,6 @@ export default {
         })
     ],
     devServer: {
-        port: 8080
+        port: 8000
     }
 };

--- a/packages/fes-template-h5/src/app.js
+++ b/packages/fes-template-h5/src/app.js
@@ -1,10 +1,13 @@
 export const request = {
     errorHandler: {
+        111(responseData) {
+            console.log(responseData);
+        },
         404() {
             console.log('to 404 page');
         },
-        commonAbnormalCodeHandler(res) {
-            console.log(res.data.code);
+        default(error) {
+            console.log(error.response.data);
         }
     }
 };

--- a/packages/fes-template-h5/src/app.js
+++ b/packages/fes-template-h5/src/app.js
@@ -1,7 +1,10 @@
 export const request = {
-    errorConfig: {
+    errorHandler: {
         404() {
             console.log('to 404 page');
+        },
+        commonAbnormalCodeHandler(res) {
+            console.log(res.data.code);
         }
     }
 };


### PR DESCRIPTION
## break change

code 非 `'0'` 的 request 会进入 reject，以方便对所有code异常请求统一处理

运行时新增配置`default` 统一异常处理:

```
export const request = {
    errorHandler: {
        11199(response) {
            // 特殊 code 处理逻辑
        },
       default(response) {
            // 非 0，且非 11199(前面已经配置过 11199) code 其他异常code处理逻辑
        }
    },
}
```