### PR TITLE
增加了 Cloud IDE 在线预览链接

### DIFF
--- a/README.en-US.md
+++ b/README.en-US.md
@@ -93,6 +93,10 @@ npm install
 npm run dev
 ```
 
+## Start On Cloud IDE
+
+[https://idegithub.com/WeBankFinTech/fes.js](https://idegithub.com/WeBankFinTech/fes.js)
+
 ## Feedback
 
 | Github Issue  | WeChat group | Fes.js开源运营小助手 |

--- a/README.md
+++ b/README.md
@@ -95,6 +95,10 @@ npm install
 npm run dev
 ```
 
+## 在 Cloud IDE 中预览
+
+[https://idegithub.com/WeBankFinTech/fes.js](https://idegithub.com/WeBankFinTech/fes.js)
+
 ## 反馈
 
 | Github Issue  | Fes.js开源运营小助手 |

--- a/preview.yml
+++ b/preview.yml
@@ -1,0 +1,10 @@
+# preview.yml
+autoOpen: true # 打开工作空间时是否自动开启所有应用的预览
+apps:
+  - port: 8080 # 应用的端口
+    run: npm i --registry=https://registry.npmmirror.com && npm run docs:dev # 应用的启动命令
+    command: # 使用此命令启动服务，且不执行run
+    root: ./ # 应用的启动目录
+    name: fes.js # 应用名称
+    description: 一个好用的前端管理台快速开发框架 # 应用描述
+    autoOpen: true # 打开工作空间时是否自动开启预览（优先级高于根级 autoOpen)


### PR DESCRIPTION
Cloud IDE 可以方便直接在云 IDE 中阅读 fes.js 的代码，我这边做了脚本默认打开安装依赖，并自动启动 docs:dev，不过也可以换其他脚本，比如创建 myapp 等。