### PR TITLE
fix: mock.js request method match

### DIFF
--- a/packages/fes-preset-built-in/src/plugins/features/mock.js
+++ b/packages/fes-preset-built-in/src/plugins/features/mock.js
@@ -137,7 +137,7 @@ export default (api) => {
                 return next();
             }
             // 请求以 cgiMock.prefix 开头，匹配处理
-            const matchRequet = requestList.find((item) => req.path.search(item.url) !== -1 && req.method === (item.method || 'GET').toUpperCase());
+            const matchRequet = requestList.find((item) => req.path.search(item.url) !== -1 && (item.method ? req.method === item.method.toUpperCase() : true));
             if (!matchRequet) {
                 return next();
             }

--- a/packages/fes-preset-built-in/src/plugins/features/mock.js
+++ b/packages/fes-preset-built-in/src/plugins/features/mock.js
@@ -137,7 +137,7 @@ export default (api) => {
                 return next();
             }
             // 请求以 cgiMock.prefix 开头，匹配处理
-            const matchRequet = requestList.find((item) => req.path.search(item.url) !== -1);
+            const matchRequet = requestList.find((item) => req.path.search(item.url) !== -1 && req.method === (item.method || 'GET').toUpperCase());
             if (!matchRequet) {
                 return next();
             }


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

-   [x ] Bugfix
-   [ ] Feature
-   [ ] Code style update
-   [ ] Refactor
-   [ ] Docs
-   [ ] Build-related changes
-   [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

-   [ ] Yes
-   [x ] No

If yes, please describe the impact and migration path for existing applications:

**Related issue (if exists):**

**Other information:**
When using the Mock feature, requests with the same URL but different methods cannot be correctly matched because the matching is currently only done based on the request URL. For example, cgiMock({url: '/api/users', method: 'GET'}) and cgiMock({url: '/api/users', method: 'POST'}) will both attempt to match the same mock configuration, which can lead to unexpected behavior.

This change introduces method-based matching to resolve the issue, allowing for distinct mock configurations for different request methods on the same URL.