### PR TITLE
ci: 升级 GitHub Actions 依赖

### DIFF
--- a/.github/workflows/cr.yml
+++ b/.github/workflows/cr.yml
@@ -15,7 +15,7 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: anc95/ChatGPT-CodeReview@main
+      - uses: anc95/ChatGPT-CodeReview@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -11,18 +11,16 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             - name: Checkout
-              uses: actions/checkout@v3
+              uses: actions/checkout@v7
 
             - name: PNPM
-              uses: pnpm/action-setup@v2
-              with:
-                  version: 8.1.0
+              uses: pnpm/action-setup@v5
 
             - name: Install and Build 🔧 # This example project is built using npm and outputs the result to the 'build' folder. Replace with the commands required to build your project, or remove this step entirely if your site is pre-built.
               run: pnpm i && pnpm docs:build
 
             - name: Deploy
-              uses: easingthemes/ssh-deploy@main
+              uses: easingthemes/ssh-deploy@v6
               env:
                   # 本地.ssh文件下的私钥id_rsa，存在secrets的TOKEN中
                   SSH_PRIVATE_KEY: ${{ secrets.HARRYWAN_PRIVATE_KEY }}
@@ -40,19 +38,17 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             - name: Checkout 🛎️
-              uses: actions/checkout@v3
+              uses: actions/checkout@v7
 
             - name: PNPM
-              uses: pnpm/action-setup@v2
-              with:
-                  version: 8.1.0
+              uses: pnpm/action-setup@v5
 
             - name: Install and Build 🔧 # This example project is built using npm and outputs the result to the 'build' folder. Replace with the commands required to build your project, or remove this step entirely if your site is pre-built.
               run: |
                   pnpm i
                   pnpm docs:build-pages
             - name: Deploy 🚀
-              uses: JamesIves/github-pages-deploy-action@v4.3.3
+              uses: JamesIves/github-pages-deploy-action@v4.9.0
               with:
                   branch: gh-pages # The branch the action should deploy to.
                   folder: docs/.vitepress/dist

--- a/.github/workflows/gitee-mirror.yml
+++ b/.github/workflows/gitee-mirror.yml
@@ -22,7 +22,7 @@ jobs:
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
     - name: Mirror the Github organization repos to Gitee.
-      uses: Yikun/hub-mirror-action@master
+      uses: Yikun/hub-mirror-action@v1.5
       with:
         src: github/WeBankFinTech
         dst: gitee/WeBank

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,7 +11,7 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             - name: Checkout code
-              uses: actions/checkout@master
+              uses: actions/checkout@v7
             - name: Get the release version from the tag
               shell: bash
               if: env.RELEASE_VERSION == ''
@@ -23,8 +23,7 @@ jobs:
                   cat notes-${{ env.RELEASE_VERSION }}.md
             - name: Create Release for Tag
               id: release_tag
-              uses: softprops/action-gh-release@v1
-              env:
-                  GITHUB_TOKEN: ${{ secrets.ACCESS_TOKEN }}
+              uses: softprops/action-gh-release@v3
               with:
+                  token: ${{ secrets.ACCESS_TOKEN }}
                   body_path: notes-${{ env.RELEASE_VERSION }}.md


### PR DESCRIPTION
## 升级内容

将各 workflow 中的 GitHub Action 依赖升级到最新可用版本。

| Action | 原版本 | 新版本 | 说明 |
| --- | --- | --- | --- |
| `actions/checkout` | v3 / master | **v7** | 工作流未使用特殊输入,风险低 |
| `pnpm/action-setup` | v2 (version 8.1.0) | **v5** | 未用 v6:v6 要求 pnpm v11+,而本项目 `packageManager` 为 `pnpm@10.14.0`,故取 v5(最新兼容版) |
| `easingthemes/ssh-deploy` | main | **v6** | 保留 `env:` 配置(v6 仍直接读 `process.env`) |
| `JamesIves/github-pages-deploy-action` | v4.3.3 | **v4.9.0** | 同大版本内升级 |
| `softprops/action-gh-release` | v1 | **v3** | 已将 `env: GITHUB_TOKEN` 改为 `with: token:`(v3 中 env 形式已废弃) |
| `Yikun/hub-mirror-action` | master | **v1.5** | 无 major tag,固定到最新发布版 |
| `anc95/ChatGPT-CodeReview` | main | **v1** | 仍用 `env:` 配置(v1 支持) |

## 附带改动

`pnpm/action-setup` 不再写死 `version: 8.1.0`,改为读取 `package.json` 的 `packageManager`(pnpm@10.14.0),修复了 CI 与项目声明版本不一致的问题。

## 验证

- 所有 YAML 语法已校验通过
- 引用的 major tag 均经 GitHub API 确认存在
- 各 action 的输入/env 兼容性已逐一核对